### PR TITLE
docs README の多言語化 / Localize docs README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,16 @@
 # UnityAgent — Public Site
 
-This directory hosts the public landing site for UnityAgent at:
+[日本語](#日本語) | [English](#english) | [繁體中文](#繁體中文) | [简体中文](#简体中文)
+
+## 日本語
+
+このディレクトリは UnityAgent の公開ランディングサイトを配置しています。
 
 - https://lighfu.github.io/unity-agent/
 
-## Stack
+### 技術スタック
 
-Static HTML / CSS / JS. No build step.
+Static HTML / CSS / JS。ビルド手順はありません。
 
 ```
 docs/
@@ -20,7 +24,7 @@ docs/
 └── .nojekyll         disables Jekyll on GitHub Pages
 ```
 
-## Local preview
+### ローカルプレビュー
 
 ```sh
 cd docs
@@ -28,15 +32,70 @@ python -m http.server 8000
 # open http://localhost:8000/
 ```
 
-## GitHub Pages
+### GitHub Pages
 
 Repository → Settings → Pages
+
+- Source: **Deploy from a branch**
+- Branch: **master**, folder: **/docs**
+
+`.nojekyll` により、静的ファイルがそのまま配信されます。
+
+### コンテンツ更新
+
+| 内容 | 場所 |
+| --- | --- |
+| Hero / sections | `index.html` (HTML structure) |
+| Translation strings | `js/i18n.js` (`STRINGS.ja` / `STRINGS.en` / `STRINGS["zh-TW"]` / `STRINGS.zh`) |
+| Tool categories | `js/data.js` (`TOOL_CATEGORIES`) |
+| Provider list | `js/data.js` (`PROVIDERS`) |
+| Changelog excerpt | `js/data.js` (`CHANGELOG`) |
+| Brand colors | `css/style.css` (`:root` variables) |
+
+### ロゴ / ブランド素材
+
+`assets/mark*.svg` と `assets/wordmark-*.svg` は正規の `UnityAgent-logo-pack` から反映されています。マスターパックを更新する場合は、`mark-*.svg` と `unityagent-*.svg` をコピーし、ファイル名が変わった場合は参照も調整してください。
+
+## English
+
+This directory hosts the public landing site for UnityAgent.
+
+- https://lighfu.github.io/unity-agent/
+
+### Stack
+
+Static HTML / CSS / JS. No build step.
+
+```
+docs/
+├── index.html        Landing page (single page, ja/en/zh-TW/zh)
+├── css/style.css
+├── js/
+│   ├── i18n.js       data-i18n based ja/en/zh-TW/zh switcher
+│   ├── data.js       tool categories / providers / changelog
+│   └── main.js       theme, tabs, dynamic rendering
+├── assets/           logos and screenshots
+└── .nojekyll         disables Jekyll on GitHub Pages
+```
+
+### Local preview
+
+```sh
+cd docs
+python -m http.server 8000
+# open http://localhost:8000/
+```
+
+### GitHub Pages
+
+Repository → Settings → Pages
+
 - Source: **Deploy from a branch**
 - Branch: **master**, folder: **/docs**
 
 The `.nojekyll` file ensures static files load as-is.
 
-## Update content
+### Update content
 
 | What | Where |
 | --- | --- |
@@ -47,8 +106,114 @@ The `.nojekyll` file ensures static files load as-is.
 | Changelog excerpt | `js/data.js` (`CHANGELOG`) |
 | Brand colors | `css/style.css` (`:root` variables) |
 
-## Logo / brand assets
+### Logo / brand assets
 
-`assets/mark*.svg` and `assets/wordmark-*.svg` are mirrored from the canonical
-`UnityAgent-logo-pack`. When updating the master pack, copy `mark-*.svg` and
-`unityagent-*.svg` over and adjust the references if filenames change.
+`assets/mark*.svg` and `assets/wordmark-*.svg` are mirrored from the canonical `UnityAgent-logo-pack`. When updating the master pack, copy `mark-*.svg` and `unityagent-*.svg` over and adjust the references if filenames change.
+
+## 繁體中文
+
+此目錄放置 UnityAgent 的公開落地頁。
+
+- https://lighfu.github.io/unity-agent/
+
+### 技術堆疊
+
+Static HTML / CSS / JS。沒有建置步驟。
+
+```
+docs/
+├── index.html        落地頁 (single page, ja/en/zh-TW/zh)
+├── css/style.css
+├── js/
+│   ├── i18n.js       data-i18n based ja/en/zh-TW/zh switcher
+│   ├── data.js       tool categories / providers / changelog
+│   └── main.js       theme, tabs, dynamic rendering
+├── assets/           logo 與截圖
+└── .nojekyll         disables Jekyll on GitHub Pages
+```
+
+### 本機預覽
+
+```sh
+cd docs
+python -m http.server 8000
+# open http://localhost:8000/
+```
+
+### GitHub Pages
+
+Repository → Settings → Pages
+
+- Source: **Deploy from a branch**
+- Branch: **master**, folder: **/docs**
+
+`.nojekyll` 檔案會確保靜態檔案依原樣載入。
+
+### 更新內容
+
+| 內容 | 位置 |
+| --- | --- |
+| Hero / sections | `index.html` (HTML structure) |
+| Translation strings | `js/i18n.js` (`STRINGS.ja` / `STRINGS.en` / `STRINGS["zh-TW"]` / `STRINGS.zh`) |
+| Tool categories | `js/data.js` (`TOOL_CATEGORIES`) |
+| Provider list | `js/data.js` (`PROVIDERS`) |
+| Changelog excerpt | `js/data.js` (`CHANGELOG`) |
+| Brand colors | `css/style.css` (`:root` variables) |
+
+### Logo / 品牌素材
+
+`assets/mark*.svg` 與 `assets/wordmark-*.svg` 由正式的 `UnityAgent-logo-pack` 同步而來。更新 master pack 時，請複製 `mark-*.svg` 與 `unityagent-*.svg`，若檔名變更也請同步調整引用。
+
+## 简体中文
+
+此目录存放 UnityAgent 的公开落地页。
+
+- https://lighfu.github.io/unity-agent/
+
+### 技术栈
+
+Static HTML / CSS / JS。没有构建步骤。
+
+```
+docs/
+├── index.html        落地页 (single page, ja/en/zh-TW/zh)
+├── css/style.css
+├── js/
+│   ├── i18n.js       data-i18n based ja/en/zh-TW/zh switcher
+│   ├── data.js       tool categories / providers / changelog
+│   └── main.js       theme, tabs, dynamic rendering
+├── assets/           logo 与截图
+└── .nojekyll         disables Jekyll on GitHub Pages
+```
+
+### 本地预览
+
+```sh
+cd docs
+python -m http.server 8000
+# open http://localhost:8000/
+```
+
+### GitHub Pages
+
+Repository → Settings → Pages
+
+- Source: **Deploy from a branch**
+- Branch: **master**, folder: **/docs**
+
+`.nojekyll` 文件会确保静态文件按原样加载。
+
+### 更新内容
+
+| 内容 | 位置 |
+| --- | --- |
+| Hero / sections | `index.html` (HTML structure) |
+| Translation strings | `js/i18n.js` (`STRINGS.ja` / `STRINGS.en` / `STRINGS["zh-TW"]` / `STRINGS.zh`) |
+| Tool categories | `js/data.js` (`TOOL_CATEGORIES`) |
+| Provider list | `js/data.js` (`PROVIDERS`) |
+| Changelog excerpt | `js/data.js` (`CHANGELOG`) |
+| Brand colors | `css/style.css` (`:root` variables) |
+
+### Logo / 品牌素材
+
+`assets/mark*.svg` 和 `assets/wordmark-*.svg` 由正式的 `UnityAgent-logo-pack` 同步而来。更新 master pack 时，请复制 `mark-*.svg` 和 `unityagent-*.svg`，如果文件名发生变化，也请同步调整引用。


### PR DESCRIPTION
## 概要 / Summary

`docs/README.md` の説明を日本語 / English / 繁體中文 / 简体中文の順に整理しました。

## 変更内容 / Changes

- Add Japanese, Traditional Chinese, and Simplified Chinese sections to `docs/README.md`.
- Keep the existing English maintenance notes while aligning the language order with the project README.
- Document the docs site structure, local preview, GitHub Pages setup, content update locations, and brand asset notes in each language.

## 補足 / Notes

- Documentation-only change.
- No changes to the public site runtime, Unity Editor code, localization loading, or generated assets.

## 確認 / Checks

- `git diff --check`
- `node --check docs/js/i18n.js`
- `node --check docs/js/data.js`
- `node --check docs/js/main.js`