### PR TITLE
Clarify browser extension listing documentation

### DIFF
--- a/BrowserExtension~/README.md
+++ b/BrowserExtension~/README.md
@@ -1,0 +1,25 @@
+# Unity Agent - Web Browser Bridge
+
+Chrome extension for connecting supported web AI chat pages to a local
+UnityAgent instance over `ws://127.0.0.1`.
+
+## Icon assets
+
+`manifest.json` references these generated icon files:
+
+- `icons/icon-16.png`
+- `icons/icon-48.png`
+- `icons/icon-128.png`
+
+They are intentionally not committed because repository-wide PNG files are
+ignored. Chrome reads these paths directly from `manifest.json`; if the files
+are missing, loading or packaging the extension can report missing icon assets
+or fall back to a default icon. Before loading or packaging the extension,
+generate them locally:
+
+```sh
+python generate_icons.py
+```
+
+The script creates the `icons/` directory and writes the three PNG files used
+by Chrome.

--- a/BrowserExtension~/STORE_LISTING.md
+++ b/BrowserExtension~/STORE_LISTING.md
@@ -40,7 +40,7 @@ Unity Agent - Web Browser Bridge connects your locally running Unity Editor AI a
 This extension communicates only with localhost (127.0.0.1). It does not collect, store, or transmit any personal information. See the full privacy policy for details.
 
 **Requirements:**
-- Unity Editor with the Unity Agent package (com.ajisaiflow.vrchat.avater)
+- Unity Editor with the UnityAgent package (com.ajisaiflow.unityagent)
 - Chrome or Chromium-based browser
 
 ---


### PR DESCRIPTION
## 概要 / Summary

ブラウザ拡張関連ドキュメントの小さな不整合を修正しました。

This PR fixes small documentation inconsistencies in the browser extension docs.

## 変更内容 / Changes

- Chrome Web Store listing 内の UnityAgent パッケージ名を修正
  - `com.ajisaiflow.vrchat.avater` → `com.ajisaiflow.unityagent`
- ブラウザ拡張用 README を追加
- `manifest.json` が参照するアイコン PNG は `generate_icons.py` でローカル生成する必要があることを明記
- アイコンが未生成の場合、拡張機能の読み込み・パッケージング時に missing icon asset の警告やデフォルトアイコンへのフォールバックが起こり得ることを説明

- Fixed the UnityAgent package name in the Chrome Web Store listing
  - `com.ajisaiflow.vrchat.avater` → `com.ajisaiflow.unityagent`
- Added a README for the browser extension
- Documented that the icon PNG files referenced by `manifest.json` must be generated locally with `generate_icons.py`
- Explained that missing generated icons may cause missing icon asset warnings during loading/packaging, or fallback to the default extension icon

## 検証 / Verification

- 旧パッケージ名が `BrowserExtension~` から削除されていることを確認
- 新しいパッケージ名がルート `package.json` と一致していることを確認
- アイコン PNG を生成・コミットしていないことを確認

- Confirmed the old package name no longer appears under `BrowserExtension~`
- Confirmed the documented package name matches the root `package.json`
- Confirmed no icon PNG files were generated or committed