### PR TITLE
Update MCP streamable HTTP handling

### DIFF
--- a/Editor/AssemblyInfo.cs
+++ b/Editor/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("AjisaiFlow.UnityAgent.Editor.Tests")]

--- a/Editor/AssemblyInfo.cs.meta
+++ b/Editor/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: afb45bb219114de5a42c292367579378
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/Bridge~/UnityAgentBridge/README.md
+++ b/Editor/Bridge~/UnityAgentBridge/README.md
@@ -1,6 +1,6 @@
 # UnityAgentBridge (Go)
 
-Out-of-process MCP HTTP/SSE endpoint that survives Unity domain reloads.
+Out-of-process MCP HTTP endpoint that survives Unity domain reloads.
 
 ## Why
 
@@ -15,14 +15,15 @@ delivery once Unity reconnects.
 ## Architecture
 
 ```
-┌─────────────┐    HTTP+SSE    ┌──────────────┐    TCP+JSONL    ┌──────────────┐
+┌─────────────┐    HTTP POST   ┌──────────────┐    TCP+JSONL    ┌──────────────┐
 │ MCP client  │ ─────────────→ │   Bridge     │ ←─────────────→ │ Unity Editor │
 │ (Claude/etc)│                │   (this)     │                 │              │
 └─────────────┘                └──────────────┘                 └──────────────┘
                                 long-lived                       reloads, reconnects
 ```
 
-- Public side: HTTP `POST /mcp` with Bearer token (matches existing AgentMCPServer.cs surface)
+- Public side: HTTP `POST /mcp` with Bearer token (matches existing AgentMCPServer.cs surface).
+  `GET /mcp` SSE is intentionally not supported in P1 and returns 405.
 - Internal side: TCP listener, line-delimited JSON, shared-secret hello
 
 ## Build

--- a/Editor/Bridge~/UnityAgentBridge/main.go
+++ b/Editor/Bridge~/UnityAgentBridge/main.go
@@ -1,16 +1,16 @@
-// UnityAgentBridge — Out-of-process MCP HTTP/SSE endpoint that survives Unity domain reloads.
+// UnityAgentBridge — Out-of-process MCP HTTP endpoint that survives Unity domain reloads.
 //
 // Architecture:
 //
-//   ┌─────────────┐    HTTP+SSE    ┌──────────────┐    TCP+JSONL    ┌──────────────┐
+//   ┌─────────────┐    HTTP POST   ┌──────────────┐    TCP+JSONL    ┌──────────────┐
 //   │ MCP client  │ ─────────────→ │   Bridge     │ ←─────────────→ │ Unity Editor │
 //   │ (Claude/etc)│                │   (this)     │                 │              │
 //   └─────────────┘                └──────────────┘                 └──────────────┘
 //                                   long-lived                       reloads, reconnects
 //
-// The bridge owns the public MCP HTTP endpoint and the persistent SSE channel for one MCP
-// client. It accepts a single Unity TCP connection. When Unity disconnects (domain reload),
-// pending tool-call requests are held in a queue and re-dispatched when Unity reconnects.
+// The bridge owns the public MCP HTTP endpoint for one MCP client. It accepts a single Unity
+// TCP connection. When Unity disconnects (domain reload), pending tool-call requests are held
+// in a queue and re-dispatched when Unity reconnects.
 //
 // P1 SCOPE: skeleton only. Just enough to:
 //   1. Accept Unity over TCP (with shared-secret token auth)
@@ -35,6 +35,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -45,11 +46,14 @@ import (
 // ─────────────────────────────────────────────────────────────────────────
 
 const (
-	defaultPublicPort   = 17800 // MCP HTTP endpoint exposed to Claude Code et al.
-	defaultInternalPort = 17801 // TCP endpoint where Unity connects in.
-	mcpEndpointPath     = "/mcp"
-	idleQuitGrace       = 5 * time.Minute  // Quit after both sides are gone for this long.
-	callTimeout         = 120 * time.Second // Per-call timeout, matches AgentMCPServer.cs default.
+	defaultPublicPort                       = 17800 // MCP HTTP endpoint exposed to Claude Code et al.
+	defaultInternalPort                     = 17801 // TCP endpoint where Unity connects in.
+	mcpEndpointPath                         = "/mcp"
+	latestProtocolVersion                   = "2025-06-18"
+	defaultProtocolVersionWhenHeaderMissing = "2025-03-26"
+	headerProtocolVersion                   = "MCP-Protocol-Version"
+	idleQuitGrace                           = 5 * time.Minute  // Quit after both sides are gone for this long.
+	callTimeout                             = 120 * time.Second // Per-call timeout, matches AgentMCPServer.cs default.
 )
 
 var (
@@ -330,6 +334,8 @@ type rpcRequest struct {
 	ID      json.RawMessage `json:"id,omitempty"`
 	Method  string          `json:"method"`
 	Params  json.RawMessage `json:"params,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
 }
 
 type rpcResponse struct {
@@ -376,16 +382,35 @@ func (b *Bridge) handleRoot(w http.ResponseWriter, r *http.Request) {
 func (b *Bridge) handleMCP(w http.ResponseWriter, r *http.Request) {
 	// CORS for local tools
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, MCP-Protocol-Version, Mcp-Session-Id, Last-Event-ID")
+	w.Header().Set("Access-Control-Expose-Headers", "MCP-Protocol-Version, Mcp-Session-Id")
+	w.Header().Set(headerProtocolVersion, latestProtocolVersion)
 
 	if r.Method == http.MethodOptions {
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
+	if !validProtocolVersionHeader(r.Header.Get(headerProtocolVersion)) {
+		http.Error(w, "unsupported MCP protocol version", http.StatusBadRequest)
+		return
+	}
+	if r.Method == http.MethodGet {
+		// Bridge P1 does not provide a standalone server-to-client SSE channel.
+		// Streamable HTTP allows servers to signal that by returning 405.
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if r.Method == http.MethodDelete {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
+	}
+	if warnPostAcceptHeader(r.Header.Get("Accept")) {
+		log.Printf("[bridge] non-compliant POST Accept header; continuing for compatibility: %q", r.Header.Get("Accept"))
 	}
 
 	// Bearer auth — must match shared token.
@@ -411,6 +436,15 @@ func (b *Bridge) handleMCP(w http.ResponseWriter, r *http.Request) {
 		log.Printf("[bridge] mcp ← %s id=%s", req.Method, string(req.ID))
 	}
 
+	if req.Method == "" && (len(req.ID) > 0 || len(req.Result) > 0 || req.Error != nil) {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+	if req.Method == "" {
+		writeJSONRPCError(w, json.RawMessage("null"), -32600, "Invalid Request", "Missing method.")
+		return
+	}
+
 	// Notifications (no response expected).
 	if len(req.ID) == 0 || string(req.ID) == "null" {
 		w.WriteHeader(http.StatusAccepted)
@@ -419,7 +453,7 @@ func (b *Bridge) handleMCP(w http.ResponseWriter, r *http.Request) {
 
 	switch req.Method {
 	case "initialize":
-		writeJSONRPCResult(w, req.ID, b.handleInitialize())
+		writeJSONRPCResult(w, req.ID, b.handleInitialize(req.Params))
 	case "ping":
 		writeJSONRPCResult(w, req.ID, map[string]any{})
 	case "tools/list":
@@ -435,6 +469,49 @@ func (b *Bridge) handleMCP(w http.ResponseWriter, r *http.Request) {
 	default:
 		writeJSONRPCError(w, req.ID, -32601, "Method not found", req.Method)
 	}
+}
+
+func negotiateProtocolVersion(requested string) string {
+	if supportedProtocolVersion(requested) {
+		return requested
+	}
+	return latestProtocolVersion
+}
+
+func supportedProtocolVersion(version string) bool {
+	switch strings.TrimSpace(version) {
+	case latestProtocolVersion, defaultProtocolVersionWhenHeaderMissing, "2024-11-05":
+		return true
+	default:
+		return false
+	}
+}
+
+func validProtocolVersionHeader(header string) bool {
+	header = strings.TrimSpace(header)
+	return header == "" || supportedProtocolVersion(header)
+}
+
+func acceptsJSONAndEventStream(header string) bool {
+	return headerContainsMediaType(header, "application/json") &&
+		headerContainsMediaType(header, "text/event-stream")
+}
+
+func warnPostAcceptHeader(header string) bool {
+	return strings.TrimSpace(header) != "" && !acceptsJSONAndEventStream(header)
+}
+
+func headerContainsMediaType(header, mediaType string) bool {
+	for _, part := range strings.Split(header, ",") {
+		item := strings.TrimSpace(part)
+		if idx := strings.IndexByte(item, ';'); idx >= 0 {
+			item = strings.TrimSpace(item[:idx])
+		}
+		if strings.EqualFold(item, mediaType) {
+			return true
+		}
+	}
+	return false
 }
 
 func (b *Bridge) checkBearer(header string) bool {
@@ -458,9 +535,18 @@ func constantTimeEq(a, b string) bool {
 
 // handleInitialize returns the same shape as AgentMCPServer.Handlers.HandleInitialize so existing
 // MCP clients (Claude Code) treat the bridge as a drop-in replacement.
-func (b *Bridge) handleInitialize() map[string]any {
+func (b *Bridge) handleInitialize(rawParams json.RawMessage) map[string]any {
+	protocolVersion := latestProtocolVersion
+	if len(rawParams) > 0 {
+		var params struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		}
+		if err := json.Unmarshal(rawParams, &params); err == nil {
+			protocolVersion = negotiateProtocolVersion(params.ProtocolVersion)
+		}
+	}
 	return map[string]any{
-		"protocolVersion": "2024-11-05",
+		"protocolVersion": protocolVersion,
 		"capabilities": map[string]any{
 			"experimental": map[string]any{},
 			"prompts":      map[string]any{"listChanged": false},

--- a/Editor/Bridge~/UnityAgentBridge/main.go
+++ b/Editor/Bridge~/UnityAgentBridge/main.go
@@ -34,6 +34,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -371,6 +372,9 @@ func (b *Bridge) startMCPHTTPServer(addr string) error {
 }
 
 func (b *Bridge) handleRoot(w http.ResponseWriter, r *http.Request) {
+	if rejectDisallowedOrigin(w, r) {
+		return
+	}
 	if r.URL.Path != "/" && r.URL.Path != "/health" {
 		http.NotFound(w, r)
 		return
@@ -380,8 +384,12 @@ func (b *Bridge) handleRoot(w http.ResponseWriter, r *http.Request) {
 }
 
 func (b *Bridge) handleMCP(w http.ResponseWriter, r *http.Request) {
+	if rejectDisallowedOrigin(w, r) {
+		return
+	}
+
 	// CORS for local tools
-	w.Header().Set("Access-Control-Allow-Origin", "*")
+	applyCORSHeaders(w, r.Header.Get("Origin"))
 	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
 	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, MCP-Protocol-Version, Mcp-Session-Id, Last-Event-ID")
 	w.Header().Set("Access-Control-Expose-Headers", "MCP-Protocol-Version, Mcp-Session-Id")
@@ -499,6 +507,50 @@ func acceptsJSONAndEventStream(header string) bool {
 
 func warnPostAcceptHeader(header string) bool {
 	return strings.TrimSpace(header) != "" && !acceptsJSONAndEventStream(header)
+}
+
+func rejectDisallowedOrigin(w http.ResponseWriter, r *http.Request) bool {
+	if validOriginHeader(r.Header.Get("Origin")) {
+		return false
+	}
+	http.Error(w, "forbidden origin", http.StatusForbidden)
+	return true
+}
+
+func applyCORSHeaders(w http.ResponseWriter, originHeader string) {
+	origin := strings.TrimSpace(originHeader)
+	if origin == "" {
+		origin = "*"
+	} else {
+		w.Header().Add("Vary", "Origin")
+	}
+	w.Header().Set("Access-Control-Allow-Origin", origin)
+}
+
+func validOriginHeader(header string) bool {
+	origin := strings.TrimSpace(header)
+	if origin == "" {
+		return true
+	}
+	if strings.EqualFold(origin, "null") {
+		return false
+	}
+	u, err := url.Parse(origin)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return false
+	}
+	if u.User != nil || (u.Path != "" && u.Path != "/") || u.RawQuery != "" || u.Fragment != "" {
+		return false
+	}
+	if !strings.EqualFold(u.Scheme, "http") && !strings.EqualFold(u.Scheme, "https") {
+		return false
+	}
+	switch strings.ToLower(u.Hostname()) {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	default:
+		return false
+	}
 }
 
 func headerContainsMediaType(header, mediaType string) bool {

--- a/Editor/Bridge~/UnityAgentBridge/main.go
+++ b/Editor/Bridge~/UnityAgentBridge/main.go
@@ -545,12 +545,12 @@ func validOriginHeader(header string) bool {
 	if !strings.EqualFold(u.Scheme, "http") && !strings.EqualFold(u.Scheme, "https") {
 		return false
 	}
-	switch strings.ToLower(u.Hostname()) {
-	case "localhost", "127.0.0.1", "::1":
+	host := strings.ToLower(u.Hostname())
+	if host == "localhost" {
 		return true
-	default:
-		return false
 	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 func headerContainsMediaType(header, mediaType string) bool {

--- a/Editor/Bridge~/UnityAgentBridge/main.go
+++ b/Editor/Bridge~/UnityAgentBridge/main.go
@@ -2,21 +2,21 @@
 //
 // Architecture:
 //
-//   ┌─────────────┐    HTTP POST   ┌──────────────┐    TCP+JSONL    ┌──────────────┐
-//   │ MCP client  │ ─────────────→ │   Bridge     │ ←─────────────→ │ Unity Editor │
-//   │ (Claude/etc)│                │   (this)     │                 │              │
-//   └─────────────┘                └──────────────┘                 └──────────────┘
-//                                   long-lived                       reloads, reconnects
+//	┌─────────────┐    HTTP POST   ┌──────────────┐    TCP+JSONL    ┌──────────────┐
+//	│ MCP client  │ ─────────────→ │   Bridge     │ ←─────────────→ │ Unity Editor │
+//	│ (Claude/etc)│                │   (this)     │                 │              │
+//	└─────────────┘                └──────────────┘                 └──────────────┘
+//	                                long-lived                       reloads, reconnects
 //
 // The bridge owns the public MCP HTTP endpoint for one MCP client. It accepts a single Unity
 // TCP connection. When Unity disconnects (domain reload), pending tool-call requests are held
 // in a queue and re-dispatched when Unity reconnects.
 //
 // P1 SCOPE: skeleton only. Just enough to:
-//   1. Accept Unity over TCP (with shared-secret token auth)
-//   2. Accept Claude Code / curl over HTTP /mcp (Bearer token auth)
-//   3. Forward `tools/call` from MCP client → Unity → response
-//   4. Survive Unity reload (buffering tool calls, replying to MCP client when Unity is back)
+//  1. Accept Unity over TCP (with shared-secret token auth)
+//  2. Accept Claude Code / curl over HTTP /mcp (Bearer token auth)
+//  3. Forward `tools/call` from MCP client → Unity → response
+//  4. Survive Unity reload (buffering tool calls, replying to MCP client when Unity is back)
 //
 // NOT in P1: OAuth discovery, SSE, multi-MCP-client, fault-tolerant reconnect after crash.
 // Those land in P2 and beyond.
@@ -53,7 +53,7 @@ const (
 	latestProtocolVersion                   = "2025-06-18"
 	defaultProtocolVersionWhenHeaderMissing = "2025-03-26"
 	headerProtocolVersion                   = "MCP-Protocol-Version"
-	idleQuitGrace                           = 5 * time.Minute  // Quit after both sides are gone for this long.
+	idleQuitGrace                           = 5 * time.Minute   // Quit after both sides are gone for this long.
 	callTimeout                             = 120 * time.Second // Per-call timeout, matches AgentMCPServer.cs default.
 )
 
@@ -393,7 +393,6 @@ func (b *Bridge) handleMCP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
 	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, MCP-Protocol-Version, Mcp-Session-Id, Last-Event-ID")
 	w.Header().Set("Access-Control-Expose-Headers", "MCP-Protocol-Version, Mcp-Session-Id")
-	w.Header().Set(headerProtocolVersion, latestProtocolVersion)
 
 	if r.Method == http.MethodOptions {
 		w.WriteHeader(http.StatusNoContent)
@@ -403,6 +402,7 @@ func (b *Bridge) handleMCP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "unsupported MCP protocol version", http.StatusBadRequest)
 		return
 	}
+	w.Header().Set(headerProtocolVersion, effectiveProtocolVersionForHeader(r.Header.Get(headerProtocolVersion)))
 	if r.Method == http.MethodGet {
 		// Bridge P1 does not provide a standalone server-to-client SSE channel.
 		// Streamable HTTP allows servers to signal that by returning 405.
@@ -444,9 +444,16 @@ func (b *Bridge) handleMCP(w http.ResponseWriter, r *http.Request) {
 		log.Printf("[bridge] mcp ← %s id=%s", req.Method, string(req.ID))
 	}
 
-	if req.Method == "" && (len(req.ID) > 0 || len(req.Result) > 0 || req.Error != nil) {
-		w.WriteHeader(http.StatusAccepted)
-		return
+	if req.Method == "" {
+		isResponse, validResponse := classifyJSONRPCResponse(req)
+		if isResponse && validResponse {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		if isResponse {
+			writeJSONRPCError(w, json.RawMessage("null"), -32600, "Invalid Request", "JSON-RPC response must include exactly one of result or error.")
+			return
+		}
 	}
 	if req.Method == "" {
 		writeJSONRPCError(w, json.RawMessage("null"), -32600, "Invalid Request", "Missing method.")
@@ -461,7 +468,9 @@ func (b *Bridge) handleMCP(w http.ResponseWriter, r *http.Request) {
 
 	switch req.Method {
 	case "initialize":
-		writeJSONRPCResult(w, req.ID, b.handleInitialize(req.Params))
+		protocolVersion := negotiateProtocolVersionFromParams(req.Params)
+		w.Header().Set(headerProtocolVersion, protocolVersion)
+		writeJSONRPCResult(w, req.ID, b.handleInitialize(protocolVersion))
 	case "ping":
 		writeJSONRPCResult(w, req.ID, map[string]any{})
 	case "tools/list":
@@ -479,11 +488,41 @@ func (b *Bridge) handleMCP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func effectiveProtocolVersionForHeader(header string) string {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return defaultProtocolVersionWhenHeaderMissing
+	}
+	return header
+}
+
 func negotiateProtocolVersion(requested string) string {
 	if supportedProtocolVersion(requested) {
 		return requested
 	}
 	return latestProtocolVersion
+}
+
+func negotiateProtocolVersionFromParams(rawParams json.RawMessage) string {
+	if len(rawParams) == 0 {
+		return latestProtocolVersion
+	}
+	var params struct {
+		ProtocolVersion string `json:"protocolVersion"`
+	}
+	if err := json.Unmarshal(rawParams, &params); err != nil {
+		return latestProtocolVersion
+	}
+	return negotiateProtocolVersion(params.ProtocolVersion)
+}
+
+func classifyJSONRPCResponse(req rpcRequest) (isResponse bool, valid bool) {
+	hasResult := len(req.Result) > 0
+	hasError := req.Error != nil
+	if !hasResult && !hasError {
+		return false, false
+	}
+	return true, len(req.ID) > 0 && hasResult != hasError
 }
 
 func supportedProtocolVersion(version string) bool {
@@ -587,16 +626,7 @@ func constantTimeEq(a, b string) bool {
 
 // handleInitialize returns the same shape as AgentMCPServer.Handlers.HandleInitialize so existing
 // MCP clients (Claude Code) treat the bridge as a drop-in replacement.
-func (b *Bridge) handleInitialize(rawParams json.RawMessage) map[string]any {
-	protocolVersion := latestProtocolVersion
-	if len(rawParams) > 0 {
-		var params struct {
-			ProtocolVersion string `json:"protocolVersion"`
-		}
-		if err := json.Unmarshal(rawParams, &params); err == nil {
-			protocolVersion = negotiateProtocolVersion(params.ProtocolVersion)
-		}
-	}
+func (b *Bridge) handleInitialize(protocolVersion string) map[string]any {
 	return map[string]any{
 		"protocolVersion": protocolVersion,
 		"capabilities": map[string]any{

--- a/Editor/Bridge~/UnityAgentBridge/main_test.go
+++ b/Editor/Bridge~/UnityAgentBridge/main_test.go
@@ -52,6 +52,36 @@ func TestProtocolVersionHeader(t *testing.T) {
 	}
 }
 
+func TestValidOriginHeaderAllowsOnlyLoopbackOrigins(t *testing.T) {
+	if !validOriginHeader("") {
+		t.Fatal("missing origin should be allowed")
+	}
+	if !validOriginHeader("http://localhost:3000") {
+		t.Fatal("localhost origin should be allowed")
+	}
+	if !validOriginHeader("http://localhost:3000/") {
+		t.Fatal("localhost origin with slash should be allowed")
+	}
+	if !validOriginHeader("https://127.0.0.1:3000") {
+		t.Fatal("127.0.0.1 origin should be allowed")
+	}
+	if !validOriginHeader("http://[::1]:3000") {
+		t.Fatal("IPv6 loopback origin should be allowed")
+	}
+	if validOriginHeader("https://example.com") {
+		t.Fatal("non-local origin should be rejected")
+	}
+	if validOriginHeader("null") {
+		t.Fatal("null origin should be rejected")
+	}
+	if validOriginHeader("file://local/test.html") {
+		t.Fatal("file origin should be rejected")
+	}
+	if validOriginHeader("http://localhost:3000/path") {
+		t.Fatal("origin with path should be rejected")
+	}
+}
+
 func TestBridgeGETMCPReturns405BecauseStandaloneSSEIsNotSupported(t *testing.T) {
 	bridge := newBridge("secret")
 	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
@@ -63,6 +93,53 @@ func TestBridgeGETMCPReturns405BecauseStandaloneSSEIsNotSupported(t *testing.T) 
 
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("expected 405, got %d", rec.Code)
+	}
+}
+
+func TestBridgePOSTRejectsNonLocalOrigin(t *testing.T) {
+	bridge := newBridge("secret")
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`))
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Origin", "https://example.com")
+	rec := httptest.NewRecorder()
+
+	bridge.handleMCP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
+	}
+}
+
+func TestBridgePOSTLocalOriginIsEchoedForCORS(t *testing.T) {
+	const origin = "http://localhost:3000"
+	bridge := newBridge("secret")
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`))
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Origin", origin)
+	rec := httptest.NewRecorder()
+
+	bridge.handleMCP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != origin {
+		t.Fatalf("expected Access-Control-Allow-Origin %q, got %q", origin, got)
+	}
+}
+
+func TestBridgeHealthRejectsNonLocalOrigin(t *testing.T) {
+	bridge := newBridge("secret")
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.Header.Set("Origin", "https://example.com")
+	rec := httptest.NewRecorder()
+
+	bridge.handleRoot(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rec.Code)
 	}
 }
 

--- a/Editor/Bridge~/UnityAgentBridge/main_test.go
+++ b/Editor/Bridge~/UnityAgentBridge/main_test.go
@@ -65,6 +65,9 @@ func TestValidOriginHeaderAllowsOnlyLoopbackOrigins(t *testing.T) {
 	if !validOriginHeader("https://127.0.0.1:3000") {
 		t.Fatal("127.0.0.1 origin should be allowed")
 	}
+	if !validOriginHeader("http://127.0.0.2:3000") {
+		t.Fatal("127.0.0.2 loopback origin should be allowed")
+	}
 	if !validOriginHeader("http://[::1]:3000") {
 		t.Fatal("IPv6 loopback origin should be allowed")
 	}

--- a/Editor/Bridge~/UnityAgentBridge/main_test.go
+++ b/Editor/Bridge~/UnityAgentBridge/main_test.go
@@ -52,6 +52,18 @@ func TestProtocolVersionHeader(t *testing.T) {
 	}
 }
 
+func TestEffectiveProtocolVersionForHeader(t *testing.T) {
+	if got := effectiveProtocolVersionForHeader(""); got != defaultProtocolVersionWhenHeaderMissing {
+		t.Fatalf("expected missing header fallback %q, got %q", defaultProtocolVersionWhenHeaderMissing, got)
+	}
+	if got := effectiveProtocolVersionForHeader("2025-03-26"); got != defaultProtocolVersionWhenHeaderMissing {
+		t.Fatalf("expected explicit compatibility version, got %q", got)
+	}
+	if got := effectiveProtocolVersionForHeader("2025-06-18"); got != latestProtocolVersion {
+		t.Fatalf("expected latest version, got %q", got)
+	}
+}
+
 func TestValidOriginHeaderAllowsOnlyLoopbackOrigins(t *testing.T) {
 	if !validOriginHeader("") {
 		t.Fatal("missing origin should be allowed")
@@ -165,6 +177,43 @@ func TestBridgePOSTMissingAcceptStaysCompatible(t *testing.T) {
 	}
 }
 
+func TestBridgeInitializeOlderProtocolKeepsResponseHeaderAndBodyAligned(t *testing.T) {
+	bridge := newBridge("secret")
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26"}}`))
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	rec := httptest.NewRecorder()
+
+	bridge.handleMCP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if got := rec.Header().Get(headerProtocolVersion); got != defaultProtocolVersionWhenHeaderMissing {
+		t.Fatalf("expected protocol header %q, got %q", defaultProtocolVersionWhenHeaderMissing, got)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, `"protocolVersion":"2025-03-26"`) {
+		t.Fatalf("expected negotiated protocol in response body, got %s", body)
+	}
+}
+
+func TestBridgePingMissingProtocolHeaderUsesCompatibilityDefault(t *testing.T) {
+	bridge := newBridge("secret")
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}`))
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	rec := httptest.NewRecorder()
+
+	bridge.handleMCP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if got := rec.Header().Get(headerProtocolVersion); got != defaultProtocolVersionWhenHeaderMissing {
+		t.Fatalf("expected protocol header %q, got %q", defaultProtocolVersionWhenHeaderMissing, got)
+	}
+}
+
 func TestBridgePOSTInvalidProtocolVersionReturns400(t *testing.T) {
 	bridge := newBridge("secret")
 	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`))
@@ -191,5 +240,70 @@ func TestBridgeNotificationReturns202(t *testing.T) {
 
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("expected 202, got %d", rec.Code)
+	}
+}
+
+func TestBridgeJSONRPCResponseReturns202(t *testing.T) {
+	bridge := newBridge("secret")
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	rec := httptest.NewRecorder()
+
+	bridge.handleMCP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", rec.Code)
+	}
+}
+
+func TestBridgeMissingMethodRequestReturnsInvalidRequest(t *testing.T) {
+	bridge := newBridge("secret")
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1}`))
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	rec := httptest.NewRecorder()
+
+	bridge.handleMCP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected JSON-RPC error over 200, got %d", rec.Code)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, `"code":-32600`) {
+		t.Fatalf("expected invalid request error, got %s", body)
+	}
+}
+
+func TestBridgeResponseWithoutIDReturnsInvalidRequest(t *testing.T) {
+	bridge := newBridge("secret")
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","result":{}}`))
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	rec := httptest.NewRecorder()
+
+	bridge.handleMCP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected JSON-RPC error over 200, got %d", rec.Code)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, `"code":-32600`) {
+		t.Fatalf("expected invalid request error, got %s", body)
+	}
+}
+
+func TestBridgeResponseWithResultAndErrorReturnsInvalidRequest(t *testing.T) {
+	bridge := newBridge("secret")
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"result":{},"error":{"code":-32000,"message":"bad"}}`))
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	rec := httptest.NewRecorder()
+
+	bridge.handleMCP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected JSON-RPC error over 200, got %d", rec.Code)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, `"code":-32600`) {
+		t.Fatalf("expected invalid request error, got %s", body)
 	}
 }

--- a/Editor/Bridge~/UnityAgentBridge/main_test.go
+++ b/Editor/Bridge~/UnityAgentBridge/main_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNegotiateProtocolVersion(t *testing.T) {
+	if got := negotiateProtocolVersion("2025-06-18"); got != latestProtocolVersion {
+		t.Fatalf("expected latest version, got %q", got)
+	}
+	if got := negotiateProtocolVersion("2099-01-01"); got != latestProtocolVersion {
+		t.Fatalf("expected fallback to latest, got %q", got)
+	}
+}
+
+func TestAcceptsJSONAndEventStream(t *testing.T) {
+	if !acceptsJSONAndEventStream("application/json, text/event-stream") {
+		t.Fatal("expected combined Accept header to be valid")
+	}
+	if !acceptsJSONAndEventStream("application/json; charset=utf-8, text/event-stream") {
+		t.Fatal("expected parameters to be ignored")
+	}
+	if acceptsJSONAndEventStream("application/json") {
+		t.Fatal("expected missing text/event-stream to be invalid")
+	}
+	if acceptsJSONAndEventStream("text/event-stream") {
+		t.Fatal("expected missing application/json to be invalid")
+	}
+	if acceptsJSONAndEventStream("*/*") {
+		t.Fatal("expected wildcard Accept to be invalid for Streamable HTTP")
+	}
+	if acceptsJSONAndEventStream("application/json, */*") {
+		t.Fatal("expected wildcard to not stand in for text/event-stream")
+	}
+}
+
+func TestProtocolVersionHeader(t *testing.T) {
+	if !validProtocolVersionHeader("") {
+		t.Fatal("missing protocol header should be allowed")
+	}
+	if !validProtocolVersionHeader("2025-06-18") {
+		t.Fatal("latest protocol version should be allowed")
+	}
+	if !validProtocolVersionHeader("2025-03-26") {
+		t.Fatal("default fallback protocol version should be allowed")
+	}
+	if validProtocolVersionHeader("not-a-date") {
+		t.Fatal("invalid protocol version should be rejected")
+	}
+}
+
+func TestBridgeGETMCPReturns405BecauseStandaloneSSEIsNotSupported(t *testing.T) {
+	bridge := newBridge("secret")
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Authorization", "Bearer secret")
+	rec := httptest.NewRecorder()
+
+	bridge.handleMCP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rec.Code)
+	}
+}
+
+func TestBridgePOSTMissingAcceptStaysCompatible(t *testing.T) {
+	bridge := newBridge("secret")
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}`))
+	req.Header.Set("Authorization", "Bearer secret")
+	rec := httptest.NewRecorder()
+
+	bridge.handleMCP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 compatibility response, got %d", rec.Code)
+	}
+	if got := rec.Header().Get(headerProtocolVersion); got != latestProtocolVersion {
+		t.Fatalf("expected protocol header %q, got %q", latestProtocolVersion, got)
+	}
+}
+
+func TestBridgePOSTInvalidProtocolVersionReturns400(t *testing.T) {
+	bridge := newBridge("secret")
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`))
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set(headerProtocolVersion, "not-a-date")
+	rec := httptest.NewRecorder()
+
+	bridge.handleMCP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}
+
+func TestBridgeNotificationReturns202(t *testing.T) {
+	bridge := newBridge("secret")
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/initialized"}`))
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	rec := httptest.NewRecorder()
+
+	bridge.handleMCP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", rec.Code)
+	}
+}

--- a/Editor/Bridge~/UnityAgentBridge/main_test.go
+++ b/Editor/Bridge~/UnityAgentBridge/main_test.go
@@ -71,6 +71,9 @@ func TestValidOriginHeaderAllowsOnlyLoopbackOrigins(t *testing.T) {
 	if !validOriginHeader("http://[::1]:3000") {
 		t.Fatal("IPv6 loopback origin should be allowed")
 	}
+	if !validOriginHeader("http://[::ffff:127.0.0.1]:3000") {
+		t.Fatal("IPv4-mapped IPv6 loopback origin should be allowed")
+	}
 	if validOriginHeader("https://example.com") {
 		t.Fatal("non-local origin should be rejected")
 	}

--- a/Editor/MCP/AgentMCPServer.Handlers.cs
+++ b/Editor/MCP/AgentMCPServer.Handlers.cs
@@ -11,15 +11,14 @@ namespace AjisaiFlow.UnityAgent.Editor.MCP
     /// </summary>
     internal static class Handlers
     {
-        // hindsight 等の動作実績ある MCP サーバーが使っている安定 version に固定する。
-        const string ProtocolVersion = "2024-11-05";
         const string ServerName = "UnityAgent";
 
         public static JNode HandleInitialize(JNode paramsNode)
         {
             string version = GetPackageVersion();
+            string protocolVersion = MCPHttpProtocol.NegotiateProtocolVersion(paramsNode);
             return JNode.Obj(
-                ("protocolVersion", JNode.Str(ProtocolVersion)),
+                ("protocolVersion", JNode.Str(protocolVersion)),
                 ("capabilities", JNode.Obj(
                     ("experimental", JNode.Obj()),
                     ("prompts", JNode.Obj(("listChanged", JNode.Bool(false)))),

--- a/Editor/MCP/AgentMCPServer.cs
+++ b/Editor/MCP/AgentMCPServer.cs
@@ -249,7 +249,6 @@ namespace AjisaiFlow.UnityAgent.Editor.MCP
             resp.AddHeader("Access-Control-Allow-Headers",
                 "Content-Type, Authorization, MCP-Protocol-Version, Mcp-Session-Id, Last-Event-ID");
             resp.AddHeader("Access-Control-Expose-Headers", "MCP-Protocol-Version, Mcp-Session-Id");
-            resp.AddHeader(MCPHttpProtocol.HeaderProtocolVersion, MCPHttpProtocol.LatestProtocolVersion);
 
             if (req.HttpMethod == "OPTIONS")
             {
@@ -396,6 +395,8 @@ namespace AjisaiFlow.UnityAgent.Editor.MCP
                     "\",\"2024-11-05\"]}");
                 return;
             }
+            resp.Headers[MCPHttpProtocol.HeaderProtocolVersion] =
+                MCPHttpProtocol.GetEffectiveProtocolVersionForHeader(protocolHeader);
 
             // GET /mcp (Accept: text/event-stream) → MCP Streamable HTTP の
             // サーバー送信イベントチャネル。Claude Code はこれが貼れないと
@@ -498,14 +499,29 @@ namespace AjisaiFlow.UnityAgent.Editor.MCP
                 return;
             }
 
-            if (root["method"].Type == JNode.JType.Null &&
-                (root.Has("result") || root.Has("error")))
+            if (root["method"].AsString == "initialize")
+                resp.Headers[MCPHttpProtocol.HeaderProtocolVersion] =
+                    MCPHttpProtocol.NegotiateProtocolVersion(root["params"]);
+
+            if (root["method"].Type == JNode.JType.Null)
             {
-                AgentLogger.Debug(LogTag.MCP, "JSON-RPC response received over Streamable HTTP; returning 202.");
-                resp.StatusCode = 202;
-                resp.ContentLength64 = 0;
-                resp.OutputStream.Close();
-                return;
+                bool hasResult = root.Has("result");
+                bool hasError = root.Has("error");
+                if (hasResult || hasError)
+                {
+                    if (!root.Has("id") || (hasResult && hasError))
+                    {
+                        WriteJsonRpcError(resp, JNode.NullNode, -32600, "Invalid Request",
+                            "JSON-RPC response must include id and exactly one of result or error.");
+                        return;
+                    }
+
+                    AgentLogger.Debug(LogTag.MCP, "JSON-RPC response received over Streamable HTTP; returning 202.");
+                    resp.StatusCode = 202;
+                    resp.ContentLength64 = 0;
+                    resp.OutputStream.Close();
+                    return;
+                }
             }
 
             DispatchJsonRpc(resp, root);

--- a/Editor/MCP/AgentMCPServer.cs
+++ b/Editor/MCP/AgentMCPServer.cs
@@ -232,8 +232,19 @@ namespace AjisaiFlow.UnityAgent.Editor.MCP
             string safeCt = SanitizeForLog(req.ContentType, 120);
             TraceLog($"REQ {safeMethod} {safePath} remote={remote} len={req.ContentLength64} ct={safeCt} auth={(req.Headers["Authorization"] != null ? "present" : "MISSING")} accept={safeAccept} ua={ua}");
 
+            string originHeader = req.Headers[MCPHttpProtocol.HeaderOrigin];
+            if (!MCPHttpProtocol.IsAllowedOrigin(originHeader))
+            {
+                string safeOrigin = SanitizeForLog(originHeader, 200);
+                AgentLogger.Warning(LogTag.MCP, $"Rejected MCP HTTP request with non-local Origin={safeOrigin} remote={remote}");
+                WriteJson(resp, 403, "{\"error\":\"forbidden_origin\"}");
+                return;
+            }
+
             // CORS (ローカルツール用)
-            resp.AddHeader("Access-Control-Allow-Origin", "*");
+            resp.AddHeader("Access-Control-Allow-Origin", MCPHttpProtocol.GetCorsAllowOriginValue(originHeader));
+            if (!string.IsNullOrWhiteSpace(originHeader))
+                resp.AddHeader("Vary", "Origin");
             resp.AddHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
             resp.AddHeader("Access-Control-Allow-Headers",
                 "Content-Type, Authorization, MCP-Protocol-Version, Mcp-Session-Id, Last-Event-ID");

--- a/Editor/MCP/AgentMCPServer.cs
+++ b/Editor/MCP/AgentMCPServer.cs
@@ -234,8 +234,11 @@ namespace AjisaiFlow.UnityAgent.Editor.MCP
 
             // CORS (ローカルツール用)
             resp.AddHeader("Access-Control-Allow-Origin", "*");
-            resp.AddHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-            resp.AddHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+            resp.AddHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
+            resp.AddHeader("Access-Control-Allow-Headers",
+                "Content-Type, Authorization, MCP-Protocol-Version, Mcp-Session-Id, Last-Event-ID");
+            resp.AddHeader("Access-Control-Expose-Headers", "MCP-Protocol-Version, Mcp-Session-Id");
+            resp.AddHeader(MCPHttpProtocol.HeaderProtocolVersion, MCPHttpProtocol.LatestProtocolVersion);
 
             if (req.HttpMethod == "OPTIONS")
             {
@@ -372,13 +375,24 @@ namespace AjisaiFlow.UnityAgent.Editor.MCP
                 return;
             }
 
+            string protocolHeader = req.Headers[MCPHttpProtocol.HeaderProtocolVersion];
+            if (!MCPHttpProtocol.IsValidProtocolVersionHeader(protocolHeader))
+            {
+                WriteJson(resp, 400,
+                    "{\"error\":\"unsupported_protocol_version\",\"supported\":[\"" +
+                    MCPHttpProtocol.LatestProtocolVersion + "\",\"" +
+                    MCPHttpProtocol.DefaultProtocolVersionWhenHeaderMissing +
+                    "\",\"2024-11-05\"]}");
+                return;
+            }
+
             // GET /mcp (Accept: text/event-stream) → MCP Streamable HTTP の
             // サーバー送信イベントチャネル。Claude Code はこれが貼れないと
             // 「capabilities: none」扱いにするため、認証が通っていれば空ストリームを維持する。
             if (req.HttpMethod == "GET")
             {
                 string accept = req.Headers["Accept"] ?? "";
-                if (accept.IndexOf("text/event-stream", StringComparison.OrdinalIgnoreCase) >= 0)
+                if (MCPHttpProtocol.AcceptsEventStream(accept))
                 {
                     if (!CheckAuth(req))
                     {
@@ -393,10 +407,24 @@ namespace AjisaiFlow.UnityAgent.Editor.MCP
                 return;
             }
 
+            if (req.HttpMethod == "DELETE")
+            {
+                WriteJson(resp, 405, "{\"error\":\"method_not_allowed\"}");
+                return;
+            }
+
             if (req.HttpMethod != "POST")
             {
                 WriteJson(resp, 405, "{\"error\":\"method_not_allowed\"}");
                 return;
+            }
+
+            string postAccept = req.Headers["Accept"] ?? "";
+            if (MCPHttpProtocol.ShouldWarnAboutPostAcceptHeader(postAccept))
+            {
+                // Keep existing clients working while surfacing the Streamable HTTP requirement.
+                AgentLogger.Warning(LogTag.MCP,
+                    $"POST /mcp from {remote} sent non-compliant Accept header; continuing for compatibility. accept={safeAccept}");
             }
 
             // Body read (size capped)
@@ -459,6 +487,16 @@ namespace AjisaiFlow.UnityAgent.Editor.MCP
                 return;
             }
 
+            if (root["method"].Type == JNode.JType.Null &&
+                (root.Has("result") || root.Has("error")))
+            {
+                AgentLogger.Debug(LogTag.MCP, "JSON-RPC response received over Streamable HTTP; returning 202.");
+                resp.StatusCode = 202;
+                resp.ContentLength64 = 0;
+                resp.OutputStream.Close();
+                return;
+            }
+
             DispatchJsonRpc(resp, root);
         }
 
@@ -476,7 +514,7 @@ namespace AjisaiFlow.UnityAgent.Editor.MCP
             }
 
             // Notifications (no response expected)
-            if (method.StartsWith("notifications/"))
+            if ((idNode == null || idNode.Type == JNode.JType.Null) || method.StartsWith("notifications/"))
             {
                 AgentLogger.Debug(LogTag.MCP, $"notification received method={method} paramsBytes={(paramsNode?.ToJson().Length ?? 0)}");
                 resp.StatusCode = 202;

--- a/Editor/MCP/AgentMCPServerBootstrap.cs
+++ b/Editor/MCP/AgentMCPServerBootstrap.cs
@@ -198,7 +198,7 @@ namespace AjisaiFlow.UnityAgent.Editor.MCP
                 AgentLogger.Error(LogTag.MCP, "[Bootstrap] Could not resolve package root; bridge binary path is empty.");
                 throw new FileNotFoundException(
                     "Bridge binary path could not be resolved (package root lookup failed). " +
-                    "Verify UnityAgent is installed as a UPM package or switch back to InProc mode.");
+                    "Verify UnityAgent is installed as a UPM package or legacy Assets package, or switch back to InProc mode.");
             }
             if (!File.Exists(binaryPath))
             {
@@ -273,7 +273,6 @@ namespace AjisaiFlow.UnityAgent.Editor.MCP
             {
                 var asm = typeof(AgentMCPServerBootstrap).Assembly;
                 string asmPath = asm.Location;
-                if (string.IsNullOrEmpty(asmPath)) return null;
 
                 // Editor assemblies live under .../Editor/<asmname>.dll or under Library/ScriptAssemblies/
                 // For source distribution, we rely on PackageInfo lookup instead.
@@ -282,13 +281,24 @@ namespace AjisaiFlow.UnityAgent.Editor.MCP
                     return pkg.resolvedPath;
 
                 // Fallback: walk up from the assembly path
-                string dir = Path.GetDirectoryName(asmPath);
-                while (!string.IsNullOrEmpty(dir))
+                if (!string.IsNullOrEmpty(asmPath))
                 {
-                    if (File.Exists(Path.Combine(dir, "package.json")))
-                        return dir;
-                    dir = Path.GetDirectoryName(dir);
+                    string dir = Path.GetDirectoryName(asmPath);
+                    while (!string.IsNullOrEmpty(dir))
+                    {
+                        if (File.Exists(Path.Combine(dir, "package.json")))
+                            return dir;
+                        dir = Path.GetDirectoryName(dir);
+                    }
                 }
+            }
+            catch { }
+            try
+            {
+                string legacyRoot = PackagePaths.PackageRoot;
+                if (!string.IsNullOrEmpty(legacyRoot) &&
+                    File.Exists(Path.Combine(legacyRoot, "package.json")))
+                    return legacyRoot;
             }
             catch { }
             return null;

--- a/Editor/MCP/MCPHttpProtocol.cs
+++ b/Editor/MCP/MCPHttpProtocol.cs
@@ -32,6 +32,15 @@ namespace AjisaiFlow.UnityAgent.Editor.MCP
             return IsSupportedProtocolVersion(headerValue.Trim());
         }
 
+        public static string GetEffectiveProtocolVersionForHeader(string headerValue)
+        {
+            if (string.IsNullOrWhiteSpace(headerValue))
+                return DefaultProtocolVersionWhenHeaderMissing;
+
+            string version = headerValue.Trim();
+            return version;
+        }
+
         public static bool AcceptsJsonAndEventStream(string acceptHeader)
         {
             return HeaderContainsMediaType(acceptHeader, "application/json")

--- a/Editor/MCP/MCPHttpProtocol.cs
+++ b/Editor/MCP/MCPHttpProtocol.cs
@@ -8,6 +8,7 @@ namespace AjisaiFlow.UnityAgent.Editor.MCP
         public const string DefaultProtocolVersionWhenHeaderMissing = "2025-03-26";
         public const string HeaderProtocolVersion = "MCP-Protocol-Version";
         public const string HeaderSessionId = "Mcp-Session-Id";
+        public const string HeaderOrigin = "Origin";
 
         public static string NegotiateProtocolVersion(JNode initializeParams)
         {
@@ -46,6 +47,34 @@ namespace AjisaiFlow.UnityAgent.Editor.MCP
         {
             return !string.IsNullOrWhiteSpace(acceptHeader)
                 && !AcceptsJsonAndEventStream(acceptHeader);
+        }
+
+        public static bool IsAllowedOrigin(string originHeader)
+        {
+            if (string.IsNullOrWhiteSpace(originHeader))
+                return true;
+
+            string origin = originHeader.Trim();
+            if (string.Equals(origin, "null", StringComparison.OrdinalIgnoreCase))
+                return false;
+            if (!Uri.TryCreate(origin, UriKind.Absolute, out var uri))
+                return false;
+            if (!string.IsNullOrEmpty(uri.UserInfo) ||
+                !string.IsNullOrEmpty(uri.Query) ||
+                !string.IsNullOrEmpty(uri.Fragment) ||
+                uri.AbsolutePath != "/")
+                return false;
+            if (!string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
+                !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            string host = uri.Host.Trim('[', ']').ToLowerInvariant();
+            return host == "localhost" || host == "127.0.0.1" || host == "::1";
+        }
+
+        public static string GetCorsAllowOriginValue(string originHeader)
+        {
+            return string.IsNullOrWhiteSpace(originHeader) ? "*" : originHeader.Trim();
         }
 
         static bool HeaderContainsMediaType(string header, string mediaType)

--- a/Editor/MCP/MCPHttpProtocol.cs
+++ b/Editor/MCP/MCPHttpProtocol.cs
@@ -1,0 +1,70 @@
+using System;
+
+namespace AjisaiFlow.UnityAgent.Editor.MCP
+{
+    internal static class MCPHttpProtocol
+    {
+        public const string LatestProtocolVersion = "2025-06-18";
+        public const string DefaultProtocolVersionWhenHeaderMissing = "2025-03-26";
+        public const string HeaderProtocolVersion = "MCP-Protocol-Version";
+        public const string HeaderSessionId = "Mcp-Session-Id";
+
+        public static string NegotiateProtocolVersion(JNode initializeParams)
+        {
+            string requested = initializeParams?["protocolVersion"].AsString;
+            return IsSupportedProtocolVersion(requested)
+                ? requested
+                : LatestProtocolVersion;
+        }
+
+        public static bool IsSupportedProtocolVersion(string version)
+        {
+            return string.Equals(version, LatestProtocolVersion, StringComparison.Ordinal)
+                || string.Equals(version, "2025-03-26", StringComparison.Ordinal)
+                || string.Equals(version, "2024-11-05", StringComparison.Ordinal);
+        }
+
+        public static bool IsValidProtocolVersionHeader(string headerValue)
+        {
+            if (string.IsNullOrWhiteSpace(headerValue))
+                return true;
+            return IsSupportedProtocolVersion(headerValue.Trim());
+        }
+
+        public static bool AcceptsJsonAndEventStream(string acceptHeader)
+        {
+            return HeaderContainsMediaType(acceptHeader, "application/json")
+                && HeaderContainsMediaType(acceptHeader, "text/event-stream");
+        }
+
+        public static bool AcceptsEventStream(string acceptHeader)
+        {
+            return HeaderContainsMediaType(acceptHeader, "text/event-stream");
+        }
+
+        public static bool ShouldWarnAboutPostAcceptHeader(string acceptHeader)
+        {
+            return !string.IsNullOrWhiteSpace(acceptHeader)
+                && !AcceptsJsonAndEventStream(acceptHeader);
+        }
+
+        static bool HeaderContainsMediaType(string header, string mediaType)
+        {
+            if (string.IsNullOrWhiteSpace(header))
+                return false;
+
+            var parts = header.Split(',');
+            foreach (string raw in parts)
+            {
+                string item = raw.Trim();
+                int semicolon = item.IndexOf(';');
+                if (semicolon >= 0)
+                    item = item.Substring(0, semicolon).Trim();
+
+                if (string.Equals(item, mediaType, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+            return false;
+        }
+    }
+}

--- a/Editor/MCP/MCPHttpProtocol.cs
+++ b/Editor/MCP/MCPHttpProtocol.cs
@@ -71,8 +71,11 @@ namespace AjisaiFlow.UnityAgent.Editor.MCP
             if (string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase))
                 return true;
 
-            return System.Net.IPAddress.TryParse(uri.Host.Trim('[', ']'), out var address)
-                && System.Net.IPAddress.IsLoopback(address);
+            if (!System.Net.IPAddress.TryParse(uri.Host.Trim('[', ']'), out var address))
+                return false;
+            if (address.IsIPv4MappedToIPv6)
+                address = address.MapToIPv4();
+            return System.Net.IPAddress.IsLoopback(address);
         }
 
         public static string GetCorsAllowOriginValue(string originHeader)

--- a/Editor/MCP/MCPHttpProtocol.cs
+++ b/Editor/MCP/MCPHttpProtocol.cs
@@ -68,8 +68,11 @@ namespace AjisaiFlow.UnityAgent.Editor.MCP
                 !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
                 return false;
 
-            string host = uri.Host.Trim('[', ']').ToLowerInvariant();
-            return host == "localhost" || host == "127.0.0.1" || host == "::1";
+            if (string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            return System.Net.IPAddress.TryParse(uri.Host.Trim('[', ']'), out var address)
+                && System.Net.IPAddress.IsLoopback(address);
         }
 
         public static string GetCorsAllowOriginValue(string originHeader)

--- a/Editor/MCP/MCPHttpProtocol.cs.meta
+++ b/Editor/MCP/MCPHttpProtocol.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3e77f9fc5bd641f28d5f03cc18431f83
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/Tests.meta
+++ b/Editor/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2be1f30c9b41470499c4e26fe38db6d1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/Tests/AgentMCPServerHttpTests.cs
+++ b/Editor/Tests/AgentMCPServerHttpTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using AjisaiFlow.UnityAgent.Editor.MCP;
+using NUnit.Framework;
+
+namespace AjisaiFlow.UnityAgent.Editor.Tests
+{
+    public sealed class AgentMCPServerHttpTests
+    {
+        AgentMCPServer _server;
+        int _port;
+        const string Token = "test-token";
+
+        [SetUp]
+        public void SetUp()
+        {
+            _port = GetFreePort();
+            _server = new AgentMCPServer();
+            _server.Start(_port, Token);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _server?.Stop();
+            _server = null;
+        }
+
+        [Test]
+        public void InitializeReturnsLatestProtocolAndResponseHeader()
+        {
+            var response = PostMcp(
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-06-18\"}}",
+                "application/json, text/event-stream");
+
+            Assert.AreEqual(200, response.StatusCode);
+            Assert.AreEqual("2025-06-18", response.Headers[MCPHttpProtocol.HeaderProtocolVersion]);
+            StringAssert.Contains("\"protocolVersion\":\"2025-06-18\"", response.Body);
+        }
+
+        [Test]
+        public void MissingAcceptHeaderStaysCompatible()
+        {
+            var response = PostMcp(
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-06-18\"}}",
+                null);
+
+            Assert.AreEqual(200, response.StatusCode);
+            StringAssert.Contains("\"protocolVersion\":\"2025-06-18\"", response.Body);
+        }
+
+        [Test]
+        public void InvalidProtocolVersionHeaderReturns400()
+        {
+            var response = PostMcp(
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\"}",
+                "application/json, text/event-stream",
+                "not-a-date");
+
+            Assert.AreEqual(400, response.StatusCode);
+        }
+
+        [Test]
+        public void NotificationReturns202()
+        {
+            var response = PostMcp(
+                "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}",
+                "application/json, text/event-stream");
+
+            Assert.AreEqual(202, response.StatusCode);
+            Assert.AreEqual("", response.Body);
+        }
+
+        ServerResponse PostMcp(string json, string accept, string protocolVersion = null)
+        {
+            var req = (HttpWebRequest)WebRequest.Create($"http://localhost:{_port}/mcp");
+            req.Method = "POST";
+            req.ContentType = "application/json";
+            req.Headers["Authorization"] = "Bearer " + Token;
+            if (!string.IsNullOrEmpty(accept))
+                req.Accept = accept;
+            if (!string.IsNullOrEmpty(protocolVersion))
+                req.Headers[MCPHttpProtocol.HeaderProtocolVersion] = protocolVersion;
+
+            byte[] body = Encoding.UTF8.GetBytes(json);
+            req.ContentLength = body.Length;
+            using (var stream = req.GetRequestStream())
+                stream.Write(body, 0, body.Length);
+
+            try
+            {
+                using (var resp = (HttpWebResponse)req.GetResponse())
+                    return ReadResponse(resp);
+            }
+            catch (WebException ex) when (ex.Response is HttpWebResponse resp)
+            {
+                using (resp)
+                    return ReadResponse(resp);
+            }
+        }
+
+        static ServerResponse ReadResponse(HttpWebResponse resp)
+        {
+            string text = "";
+            using (var stream = resp.GetResponseStream())
+            {
+                if (stream != null)
+                {
+                    using (var reader = new StreamReader(stream, Encoding.UTF8))
+                        text = reader.ReadToEnd();
+                }
+            }
+            return new ServerResponse
+            {
+                StatusCode = (int)resp.StatusCode,
+                Body = text,
+                Headers = resp.Headers,
+            };
+        }
+
+        static int GetFreePort()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+
+        struct ServerResponse
+        {
+            public int StatusCode;
+            public string Body;
+            public WebHeaderCollection Headers;
+        }
+    }
+}

--- a/Editor/Tests/AgentMCPServerHttpTests.cs
+++ b/Editor/Tests/AgentMCPServerHttpTests.cs
@@ -64,6 +64,30 @@ namespace AjisaiFlow.UnityAgent.Editor.Tests
         }
 
         [Test]
+        public void NonLocalOriginReturns403()
+        {
+            var response = PostMcp(
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\"}",
+                "application/json, text/event-stream",
+                origin: "https://example.com");
+
+            Assert.AreEqual(403, response.StatusCode);
+        }
+
+        [Test]
+        public void LocalOriginIsAllowedAndEchoedForCors()
+        {
+            const string Origin = "http://localhost:3000";
+            var response = PostMcp(
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\"}",
+                "application/json, text/event-stream",
+                origin: Origin);
+
+            Assert.AreEqual(200, response.StatusCode);
+            Assert.AreEqual(Origin, response.Headers["Access-Control-Allow-Origin"]);
+        }
+
+        [Test]
         public void NotificationReturns202()
         {
             var response = PostMcp(
@@ -74,7 +98,7 @@ namespace AjisaiFlow.UnityAgent.Editor.Tests
             Assert.AreEqual("", response.Body);
         }
 
-        ServerResponse PostMcp(string json, string accept, string protocolVersion = null)
+        ServerResponse PostMcp(string json, string accept, string protocolVersion = null, string origin = null)
         {
             var req = (HttpWebRequest)WebRequest.Create($"http://localhost:{_port}/mcp");
             req.Method = "POST";
@@ -84,6 +108,8 @@ namespace AjisaiFlow.UnityAgent.Editor.Tests
                 req.Accept = accept;
             if (!string.IsNullOrEmpty(protocolVersion))
                 req.Headers[MCPHttpProtocol.HeaderProtocolVersion] = protocolVersion;
+            if (!string.IsNullOrEmpty(origin))
+                req.Headers[MCPHttpProtocol.HeaderOrigin] = origin;
 
             byte[] body = Encoding.UTF8.GetBytes(json);
             req.ContentLength = body.Length;

--- a/Editor/Tests/AgentMCPServerHttpTests.cs
+++ b/Editor/Tests/AgentMCPServerHttpTests.cs
@@ -53,6 +53,29 @@ namespace AjisaiFlow.UnityAgent.Editor.Tests
         }
 
         [Test]
+        public void InitializeOlderProtocolKeepsResponseHeaderAndBodyAligned()
+        {
+            var response = PostMcp(
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-03-26\"}}",
+                "application/json, text/event-stream");
+
+            Assert.AreEqual(200, response.StatusCode);
+            Assert.AreEqual("2025-03-26", response.Headers[MCPHttpProtocol.HeaderProtocolVersion]);
+            StringAssert.Contains("\"protocolVersion\":\"2025-03-26\"", response.Body);
+        }
+
+        [Test]
+        public void MissingProtocolHeaderUsesCompatibilityDefaultForNonInitializeRequest()
+        {
+            var response = PostMcp(
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}",
+                "application/json, text/event-stream");
+
+            Assert.AreEqual(200, response.StatusCode);
+            Assert.AreEqual("2025-03-26", response.Headers[MCPHttpProtocol.HeaderProtocolVersion]);
+        }
+
+        [Test]
         public void InvalidProtocolVersionHeaderReturns400()
         {
             var response = PostMcp(
@@ -96,6 +119,39 @@ namespace AjisaiFlow.UnityAgent.Editor.Tests
 
             Assert.AreEqual(202, response.StatusCode);
             Assert.AreEqual("", response.Body);
+        }
+
+        [Test]
+        public void JsonRpcResponseReturns202()
+        {
+            var response = PostMcp(
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}",
+                "application/json, text/event-stream");
+
+            Assert.AreEqual(202, response.StatusCode);
+            Assert.AreEqual("", response.Body);
+        }
+
+        [Test]
+        public void MissingMethodRequestReturnsInvalidRequest()
+        {
+            var response = PostMcp(
+                "{\"jsonrpc\":\"2.0\",\"id\":1}",
+                "application/json, text/event-stream");
+
+            Assert.AreEqual(200, response.StatusCode);
+            StringAssert.Contains("\"code\":-32600", response.Body);
+        }
+
+        [Test]
+        public void JsonRpcResponseWithoutIdReturnsInvalidRequest()
+        {
+            var response = PostMcp(
+                "{\"jsonrpc\":\"2.0\",\"result\":{}}",
+                "application/json, text/event-stream");
+
+            Assert.AreEqual(200, response.StatusCode);
+            StringAssert.Contains("\"code\":-32600", response.Body);
         }
 
         ServerResponse PostMcp(string json, string accept, string protocolVersion = null, string origin = null)

--- a/Editor/Tests/AgentMCPServerHttpTests.cs.meta
+++ b/Editor/Tests/AgentMCPServerHttpTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b4bf7bbd3f94432c93644393997f5b31
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/Tests/MCPHttpProtocolTests.cs
+++ b/Editor/Tests/MCPHttpProtocolTests.cs
@@ -69,6 +69,7 @@ namespace AjisaiFlow.UnityAgent.Editor.Tests
             Assert.IsTrue(MCPHttpProtocol.IsAllowedOrigin("https://127.0.0.1:3000"));
             Assert.IsTrue(MCPHttpProtocol.IsAllowedOrigin("http://127.0.0.2:3000"));
             Assert.IsTrue(MCPHttpProtocol.IsAllowedOrigin("http://[::1]:3000"));
+            Assert.IsTrue(MCPHttpProtocol.IsAllowedOrigin("http://[::ffff:127.0.0.1]:3000"));
             Assert.IsFalse(MCPHttpProtocol.IsAllowedOrigin("https://example.com"));
             Assert.IsFalse(MCPHttpProtocol.IsAllowedOrigin("null"));
             Assert.IsFalse(MCPHttpProtocol.IsAllowedOrigin("file://local/test.html"));

--- a/Editor/Tests/MCPHttpProtocolTests.cs
+++ b/Editor/Tests/MCPHttpProtocolTests.cs
@@ -58,5 +58,20 @@ namespace AjisaiFlow.UnityAgent.Editor.Tests
             Assert.IsTrue(MCPHttpProtocol.IsValidProtocolVersionHeader("2025-03-26"));
             Assert.IsFalse(MCPHttpProtocol.IsValidProtocolVersionHeader("not-a-date"));
         }
+
+        [Test]
+        public void OriginHeaderAllowsOnlyLoopbackOrigins()
+        {
+            Assert.IsTrue(MCPHttpProtocol.IsAllowedOrigin(null));
+            Assert.IsTrue(MCPHttpProtocol.IsAllowedOrigin(""));
+            Assert.IsTrue(MCPHttpProtocol.IsAllowedOrigin("http://localhost:3000"));
+            Assert.IsTrue(MCPHttpProtocol.IsAllowedOrigin("http://localhost:3000/"));
+            Assert.IsTrue(MCPHttpProtocol.IsAllowedOrigin("https://127.0.0.1:3000"));
+            Assert.IsTrue(MCPHttpProtocol.IsAllowedOrigin("http://[::1]:3000"));
+            Assert.IsFalse(MCPHttpProtocol.IsAllowedOrigin("https://example.com"));
+            Assert.IsFalse(MCPHttpProtocol.IsAllowedOrigin("null"));
+            Assert.IsFalse(MCPHttpProtocol.IsAllowedOrigin("file://local/test.html"));
+            Assert.IsFalse(MCPHttpProtocol.IsAllowedOrigin("http://localhost:3000/path"));
+        }
     }
 }

--- a/Editor/Tests/MCPHttpProtocolTests.cs
+++ b/Editor/Tests/MCPHttpProtocolTests.cs
@@ -60,6 +60,15 @@ namespace AjisaiFlow.UnityAgent.Editor.Tests
         }
 
         [Test]
+        public void EffectiveProtocolVersionUsesCompatibilityDefaultWhenHeaderIsMissing()
+        {
+            Assert.AreEqual("2025-03-26", MCPHttpProtocol.GetEffectiveProtocolVersionForHeader(null));
+            Assert.AreEqual("2025-03-26", MCPHttpProtocol.GetEffectiveProtocolVersionForHeader(""));
+            Assert.AreEqual("2025-03-26", MCPHttpProtocol.GetEffectiveProtocolVersionForHeader("2025-03-26"));
+            Assert.AreEqual("2025-06-18", MCPHttpProtocol.GetEffectiveProtocolVersionForHeader("2025-06-18"));
+        }
+
+        [Test]
         public void OriginHeaderAllowsOnlyLoopbackOrigins()
         {
             Assert.IsTrue(MCPHttpProtocol.IsAllowedOrigin(null));

--- a/Editor/Tests/MCPHttpProtocolTests.cs
+++ b/Editor/Tests/MCPHttpProtocolTests.cs
@@ -1,0 +1,62 @@
+using AjisaiFlow.UnityAgent.Editor.MCP;
+using NUnit.Framework;
+
+namespace AjisaiFlow.UnityAgent.Editor.Tests
+{
+    public sealed class MCPHttpProtocolTests
+    {
+        [Test]
+        public void NegotiatesLatestProtocolVersion()
+        {
+            var result = MCPHttpProtocol.NegotiateProtocolVersion(JNode.Obj(
+                ("protocolVersion", JNode.Str("2025-06-18"))));
+
+            Assert.AreEqual("2025-06-18", result);
+        }
+
+        [Test]
+        public void FallsBackToLatestWhenRequestedVersionIsUnsupported()
+        {
+            var result = MCPHttpProtocol.NegotiateProtocolVersion(JNode.Obj(
+                ("protocolVersion", JNode.Str("2099-01-01"))));
+
+            Assert.AreEqual("2025-06-18", result);
+        }
+
+        [Test]
+        public void PostAcceptHeaderMustIncludeJsonAndEventStream()
+        {
+            Assert.IsTrue(MCPHttpProtocol.AcceptsJsonAndEventStream("application/json, text/event-stream"));
+            Assert.IsTrue(MCPHttpProtocol.AcceptsJsonAndEventStream("application/json; charset=utf-8, text/event-stream"));
+            Assert.IsFalse(MCPHttpProtocol.AcceptsJsonAndEventStream("application/json"));
+            Assert.IsFalse(MCPHttpProtocol.AcceptsJsonAndEventStream("text/event-stream"));
+            Assert.IsFalse(MCPHttpProtocol.AcceptsJsonAndEventStream("*/*"));
+            Assert.IsFalse(MCPHttpProtocol.AcceptsJsonAndEventStream("application/json, */*"));
+        }
+
+        [Test]
+        public void MissingAcceptHeaderIsCompatibilityPath()
+        {
+            Assert.IsFalse(MCPHttpProtocol.ShouldWarnAboutPostAcceptHeader(null));
+            Assert.IsFalse(MCPHttpProtocol.ShouldWarnAboutPostAcceptHeader(""));
+        }
+
+        [Test]
+        public void ExplicitNonCompliantAcceptHeaderIsWarningPath()
+        {
+            Assert.IsTrue(MCPHttpProtocol.ShouldWarnAboutPostAcceptHeader("application/json"));
+            Assert.IsTrue(MCPHttpProtocol.ShouldWarnAboutPostAcceptHeader("*/*"));
+            Assert.IsFalse(MCPHttpProtocol.ShouldWarnAboutPostAcceptHeader("application/json, text/event-stream"));
+        }
+
+        [Test]
+        public void ProtocolVersionHeaderAllowsMissingOrSupportedVersionsOnly()
+        {
+            Assert.IsTrue(MCPHttpProtocol.IsValidProtocolVersionHeader(null));
+            Assert.IsTrue(MCPHttpProtocol.IsValidProtocolVersionHeader(""));
+            Assert.IsTrue(MCPHttpProtocol.IsValidProtocolVersionHeader("2025-06-18"));
+            Assert.IsTrue(MCPHttpProtocol.IsValidProtocolVersionHeader("2025-03-26"));
+            Assert.IsFalse(MCPHttpProtocol.IsValidProtocolVersionHeader("not-a-date"));
+        }
+    }
+}

--- a/Editor/Tests/MCPHttpProtocolTests.cs
+++ b/Editor/Tests/MCPHttpProtocolTests.cs
@@ -67,6 +67,7 @@ namespace AjisaiFlow.UnityAgent.Editor.Tests
             Assert.IsTrue(MCPHttpProtocol.IsAllowedOrigin("http://localhost:3000"));
             Assert.IsTrue(MCPHttpProtocol.IsAllowedOrigin("http://localhost:3000/"));
             Assert.IsTrue(MCPHttpProtocol.IsAllowedOrigin("https://127.0.0.1:3000"));
+            Assert.IsTrue(MCPHttpProtocol.IsAllowedOrigin("http://127.0.0.2:3000"));
             Assert.IsTrue(MCPHttpProtocol.IsAllowedOrigin("http://[::1]:3000"));
             Assert.IsFalse(MCPHttpProtocol.IsAllowedOrigin("https://example.com"));
             Assert.IsFalse(MCPHttpProtocol.IsAllowedOrigin("null"));

--- a/Editor/Tests/MCPHttpProtocolTests.cs.meta
+++ b/Editor/Tests/MCPHttpProtocolTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f6e6c4ae6af4ef49c3fa354d14efc90
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/Tests/UnityAgent.Editor.Tests.asmdef
+++ b/Editor/Tests/UnityAgent.Editor.Tests.asmdef
@@ -1,0 +1,23 @@
+{
+    "name": "AjisaiFlow.UnityAgent.Editor.Tests",
+    "rootNamespace": "AjisaiFlow.UnityAgent.Editor.Tests",
+    "references": [
+        "AjisaiFlow.UnityAgent.Editor"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Editor/Tests/UnityAgent.Editor.Tests.asmdef.meta
+++ b/Editor/Tests/UnityAgent.Editor.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 93210d3cfb534d58bd54ce86e9c2edcb
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Upgrade the UnityAgent MCP HTTP server/bridge handling toward the 2025-06-18 Streamable HTTP protocol version.
- Centralize protocol-version, Accept-header, Origin, CORS, and protocol response-header handling for Unity editor HTTP handlers and the Go bridge.
- Return 202 only for JSON-RPC notifications and valid JSON-RPC responses; invalid request/response shapes now return JSON-RPC -32600 instead of being accepted silently.
- Keep Bridge GET /mcp returning 405 until a standalone SSE stream is implemented.
- Add focused tests for MCP HTTP protocol helpers, Unity editor handlers, and Go bridge HTTP behavior.
- Keep Bridge binary resolution working for both UPM installs and legacy Assets-based test packages.

## Review feedback addressed
- Fixed protocol response headers so supported older versions and missing-header compatibility defaults do not always report the latest protocol version.
- Fixed Go bridge response classification so `{ "id": 1 }` is rejected instead of returning 202.
- Tightened JSON-RPC response validation in both Go and C# so responses require `id` and exactly one of `result` or `error`.

## Verification
- `git diff --check`
- `gofmt main.go main_test.go` in `Editor/Bridge~/UnityAgentBridge`
- `go test ./...` in `Editor/Bridge~/UnityAgentBridge` => `ok github.com/lighfu/unity-agent/bridge 0.460s`
- Built bridge binaries locally for win-x64/linux-x64/osx-x64/osx-arm64 earlier in this PR.
- Smoke-tested win-x64 bridge earlier in this PR: `/health` => 200, `GET /mcp` => 405, notification POST => 202 with `MCP-Protocol-Version: 2025-06-18`.
- Built/import-tested a local `.unitypackage` in Unity 2022.3.22f1 earlier in this PR; UnityAgent menu item registered successfully in a clean temporary project when SDK + MD3 dependencies were included.

## Notes
- Unity Editor test runner coverage is still not rerun in this follow-up environment because Unity CLI is not available here.
