### PR TITLE
ci: リリース zip 内 package.json の文字化けを公開前に検出する

### DIFF
--- a/.github/scripts/verify-package-json.py
+++ b/.github/scripts/verify-package-json.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Guard the package.json that ships inside a VPM release zip.
+
+The published listing (https://lighfu.github.io/vpm/index.json) embeds this file
+verbatim, once per version, forever. In 0.3.0 through 0.4.8 a Japanese legacyFolders
+path was read as CP932 instead of UTF-8 by the local version-bump step, and since the
+mangled text was committed back, every release re-mangled it: the field four-folded per
+release and eventually grew the listing to 37 MB. Nothing downstream can undo that -
+the decode is lossy - so the only place to stop it is before the zip is published.
+
+Usage: verify-package-json.py <release.zip>
+"""
+
+import json
+import sys
+import zipfile
+
+MAX_BYTES = 65536
+
+
+def fail(msg):
+    print(f"::error::{msg}")
+    sys.exit(1)
+
+
+def main():
+    if len(sys.argv) != 2:
+        fail("usage: verify-package-json.py <release.zip>")
+    zip_path = sys.argv[1]
+
+    with zipfile.ZipFile(zip_path) as z:
+        hits = [n for n in z.namelist() if n == "package.json"]
+        if len(hits) != 1:
+            fail(f"expected exactly one package.json at the root of {zip_path}, found {len(hits)}")
+        raw = z.read("package.json")
+
+    if len(raw) > MAX_BYTES:
+        fail(f"package.json is {len(raw)} bytes - absurdly large, suspect duplicated or mangled fields")
+
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as e:
+        fail(f"package.json is not valid UTF-8: {e}")
+
+    try:
+        json.loads(text)
+    except json.JSONDecodeError as e:
+        fail(f"package.json is not valid JSON: {e}")
+
+    bad = sorted({c for c in text if ord(c) > 127})
+    if bad:
+        shown = " ".join(f"{c}(U+{ord(c):04X})" for c in bad[:20])
+        more = f" (+{len(bad) - 20} more)" if len(bad) > 20 else ""
+        fail(
+            f"package.json contains non-ASCII characters: {shown}{more}. "
+            "Mojibake here is invisible at first - the initial CP932 round-trip changed "
+            "151 bytes to 196 - so this check refuses non-ASCII outright. If the characters "
+            "are intentional, confirm the file really is UTF-8 and relax this check on purpose."
+        )
+
+    print(f"package.json OK: {len(raw)} bytes, ASCII-only, valid JSON")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release-editor.yml
+++ b/.github/workflows/release-editor.yml
@@ -85,6 +85,9 @@ jobs:
             -x "SDK/*" "SDK.meta" \
             -x "docs/*" "docs.meta"
 
+      - name: Verify packaged package.json
+        run: python3 .github/scripts/verify-package-json.py "com.ajisaiflow.unityagent-${{ steps.version.outputs.version }}.zip"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -32,6 +32,9 @@ jobs:
           cd SDK
           zip -r "../com.ajisaiflow.unityagent.sdk-${{ steps.version.outputs.version }}.zip" .
 
+      - name: Verify packaged package.json
+        run: python3 .github/scripts/verify-package-json.py "com.ajisaiflow.unityagent.sdk-${{ steps.version.outputs.version }}.zip"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## 背景

公開 VPM listing (`https://lighfu.github.io/vpm/index.json`) が 37 MB に肥大していた問題の再発防止です。

原因は `com.ajisaiflow.unityagent` の `legacyFolders` に入っていた日本語パス `Assets\紫陽花広場\UnityAgent\...` が、リリース毎のバージョン更新時に **UTF-8 バイト列を CP932 として非可逆デコード**されていたこと。化けたまま commit されるため次のリリースで再度化け、**1 リリースあたり約 4 倍**に成長していました（0.3.16 単独で 21 MB、1 キー 234 万文字）。

listing は package.json をバージョン毎に丸ごと埋め込むため、一度公開されると恒久的に残ります。デコードは `・` や `?` に潰れる非可逆変換なので後から復元できず、**公開前に止めるしかありません**。

汚染済みの 18 バージョンは修正済み（37,322,988 → 86,963 バイト、162 バージョン全数維持）。本 PR はその再発防止です。

## 変更

`.github/scripts/verify-package-json.py` を追加し、`release-editor.yml` / `release-sdk.yml` の **zip 作成後・Release 作成前**に実行します。

検査項目:

| 項目 | 理由 |
|---|---|
| root に `package.json` が 1 つだけ存在 | listing が読む対象そのもの |
| 有効な UTF-8 | 破損バイトの検出 |
| 有効な JSON | 構文破壊の検出 |
| 64 KB 以下 | 暴走した肥大の検出 |
| **非 ASCII 文字を含まない** | 化けの初回検出 |

初回の化けは **151 → 196 バイト**とほぼ無痕跡で、文字数もほぼ変わらず `U+FFFD` も含まないため、サイズ・長さ・置換文字のいずれでも判別できません。そのため非 ASCII そのものを拒否しています。現行の `package.json` は Editor (618 B) / SDK (251 B) とも純 ASCII なので誤検知はありません。意図的に日本語を入れる場合はエラーメッセージがその旨を案内します。

## 検証

コミット前に実データで 8 ケース確認済み（すべて期待通り）:

```
現行 editor package.json          exit=0  ← 通過
現行 SDK package.json             exit=0  ← 通過
初回の化け (実データ 0.3.0)        exit=1  ← 検出
完全に肥大 (実データ 0.3.16, 21MB) exit=1  ← 検出
正しい日本語パス (実データ 0.2.2)   exit=1  ← 設計通り拒否
不正な UTF-8 バイト                exit=1
壊れた JSON                       exit=1
package.json 欠落                 exit=1
```

実際のリリース zip と同じレイアウト（editor は repo root、sdk は `SDK/` を root 化）を模した zip でも両方通過することを確認しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)